### PR TITLE
Add 'skip_last_n_seconds' config parameter for incremental replication

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -393,6 +393,7 @@ def main_impl():
     args = parse_args(REQUIRED_CONFIG_KEYS)
 
     limit = args.config.get('limit')
+    offset = args.config.get('offset')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -409,7 +410,8 @@ def main_impl():
         'break_at_end_lsn': args.config.get('break_at_end_lsn', True),
         'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
         'use_secondary': args.config.get('use_secondary', False),
-        'limit': int(limit) if limit else None
+        'limit': int(limit) if limit else None,
+        'offset': int(offset) if offset else None
     }
 
     if conn_config['use_secondary']:

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -393,7 +393,7 @@ def main_impl():
     args = parse_args(REQUIRED_CONFIG_KEYS)
 
     limit = args.config.get('limit')
-    offset = args.config.get('offset')
+    skip_last_n_seconds = args.config.get('skip_last_n_seconds')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -411,7 +411,7 @@ def main_impl():
         'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
         'use_secondary': args.config.get('use_secondary', False),
         'limit': int(limit) if limit else None,
-        'offset': int(offset) if offset else None
+        'skip_last_n_seconds': int(skip_last_n_seconds) if skip_last_n_seconds else None
     }
 
     if conn_config['use_secondary']:

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -88,7 +88,7 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                               "schema_name": schema_name,
                                               "table_name": stream['table_name'],
                                               "limit": conn_info['limit'],
-                                              "offset": conn_info['offset']
+                                              "skip_last_n_seconds": conn_info['skip_last_n_seconds']
                                               })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -135,7 +135,7 @@ def _get_select_sql(params):
     where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
         if replication_key_value else ""
 
-    where_skip = f"{replication_key} <= NOW() - interval \'{params["skip_last_n_seconds"]} seconds\'" \
+    where_skip = f"{replication_key} <= NOW() - interval '{params["skip_last_n_seconds"]} seconds'" \
         if params["skip_last_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") else ""
 
     where_statement = f"WHERE {where_incr}{' AND ' if where_incr and where_skip else ''}{where_skip}" \

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -132,7 +132,7 @@ def _get_select_sql(params):
 
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
 
-    where_incr = f"WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
+    where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
         if replication_key_value else ""
 
     where_skip = f"{replication_key} <= NOW() - interval \'{params["skip_last_n_seconds"]} seconds\'" \

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -87,7 +87,8 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                               "replication_key_value": replication_key_value,
                                               "schema_name": schema_name,
                                               "table_name": stream['table_name'],
-                                              "limit": conn_info['limit']
+                                              "limit": conn_info['limit'],
+                                              "offset": conn_info['offset']
                                               })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)
@@ -130,7 +131,15 @@ def _get_select_sql(params):
     table_name = params['table_name']
 
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
-    where_statement = f"WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
+
+    if not params["offset"] or not replication_key_value:
+        offset = ''
+    elif replication_key_sql_datatype.startswith('timestamp')':
+        offset = f' - interval \'{params["offset"]} seconds\''
+    else:
+        offset = f' - {params["offset"]}'
+
+    where_statement = f"WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}{offset}" \
         if replication_key_value else ""
 
     select_sql = f"""

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -134,7 +134,7 @@ def _get_select_sql(params):
 
     if not params["offset"] or not replication_key_value:
         offset = ''
-    elif replication_key_sql_datatype.startswith('timestamp')':
+    elif replication_key_sql_datatype.startswith('timestamp'):
         offset = f' - interval \'{params["offset"]} seconds\''
     else:
         offset = f' - {params["offset"]}'

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -135,7 +135,7 @@ def _get_select_sql(params):
     where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
         if replication_key_value else ""
 
-    where_skip = f"{replication_key} <= NOW() - interval '{params["skip_last_n_seconds"]} seconds'" \
+    where_skip = f"{replication_key} <= NOW() - interval '{params['skip_last_n_seconds']} seconds'" \
         if params["skip_last_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") else ""
 
     where_statement = f"WHERE {where_incr}{' AND ' if where_incr and where_skip else ''}{where_skip}" \

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -30,7 +30,8 @@ class TestIncremental(TestCase):
             'password': 'foo_pass',
             'port': 12345,
             'use_secondary': False,
-            'limit': None
+            'limit': None,
+            'offset': None
         }
         self.stream = {'tap_stream_id': 5, 'stream': 'bar', 'table_name': 'pg_tbl'}
         self.md_map = {

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -31,7 +31,7 @@ class TestIncremental(TestCase):
             'port': 12345,
             'use_secondary': False,
             'limit': None,
-            'offset': None
+            'skip_last_n_seconds': None
         }
         self.stream = {'tap_stream_id': 5, 'stream': 'bar', 'table_name': 'pg_tbl'}
         self.md_map = {


### PR DESCRIPTION
## Problem

_Describe the problem your PR is trying to solve_

- `updated_at` in Hanami models are generated by Ruby code (i.e. `Time.now`)
- There is a gap between when `Time.now` is executed and the UPDATE/INSERT SQL is executed.
- When multiple Ruby processes for different linux servers actively insert/update rows, the clock in each server may run out-of-sync.

When elt-run job is replicating the rows, and multiple concurrent processes from source applications are busy update/insert the rows.
There is a high chance that, some rows will be actually inserted/updated slightly later, but with earlier timestamps. OR inserted/updated slightly earlier, but with a future timestamp.
When the EL job is replicating these newly insert/updated rows, there is a high chance that some rows that inserted/updated slightly later, but with earlier timestamp will get ignored.

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Added a new config value (`skip_last_n_seconds`) that is uses by incremental replication. If it's set, timestamp based incremental replication will skip the rows updated in the last n second. 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
