### PR TITLE
[App Feature] POC: Look back n seconds 

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -394,6 +394,7 @@ def main_impl():
 
     limit = args.config.get('limit')
     skip_last_n_seconds = args.config.get('skip_last_n_seconds')
+    look_back_n_seconds = args.config.get('look_back_n_seconds')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -411,7 +412,8 @@ def main_impl():
         'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
         'use_secondary': args.config.get('use_secondary', False),
         'limit': int(limit) if limit else None,
-        'skip_last_n_seconds': int(skip_last_n_seconds) if skip_last_n_seconds else None
+        'skip_last_n_seconds': int(skip_last_n_seconds) if skip_last_n_seconds else None,
+        'look_back_n_seconds': int(look_back_n_seconds) if look_back_n_seconds else None
     }
 
     if conn_config['use_secondary']:

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -88,7 +88,8 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                               "schema_name": schema_name,
                                               "table_name": stream['table_name'],
                                               "limit": conn_info['limit'],
-                                              "skip_last_n_seconds": conn_info['skip_last_n_seconds']
+                                              "skip_last_n_seconds": conn_info['skip_last_n_seconds'],
+                                              "look_back_n_seconds": conn_info['look_back_n_seconds']
                                               })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)
@@ -134,6 +135,9 @@ def _get_select_sql(params):
 
     where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
         if replication_key_value else ""
+    
+    where_incr += f" - interval '{params['look_back_n_seconds']} seconds'" \
+        if params["look_back_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") and replication_key_value else ""
 
     where_skip = f"{replication_key} <= NOW() - interval '{params['skip_last_n_seconds']} seconds'" \
         if params["skip_last_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") else ""

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -31,7 +31,8 @@ class TestIncremental(TestCase):
             'port': 12345,
             'use_secondary': False,
             'limit': None,
-            'skip_last_n_seconds': None
+            'skip_last_n_seconds': None,
+            'look_back_n_seconds': None
         }
         self.stream = {'tap_stream_id': 5, 'stream': 'bar', 'table_name': 'pg_tbl'}
         self.md_map = {


### PR DESCRIPTION
# Background

Due to the limitation of the current implementation of the `tap-postgres replication` to skip n seconds, we try to propose another solution in this PR. 

# Design

Taking inspiration from Meltano incremental models, the new implementation is to take the last bookmarked timestamp - N seconds, so that we replicate the last few older records that we have replicated in previous replication.

# Impact

With this implementation, some issues causing data to miss out will be overcome. 

# Caveats

None

# Testing

None

# Docs

None