### PR TITLE
Bump Python version to `<3.13`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='pipelinewise-tap-postgres',
           'License :: OSI Approved :: GNU Affero General Public License v3',
           'Programming Language :: Python :: 3 :: Only'
       ],
-      python_requires=">=3.7,<3.10",
+      python_requires=">=3.7,<3.13",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'psycopg2-binary==2.9.5',


### PR DESCRIPTION
## Problem

- We've been using `--force` flag to ignore its Python version and installing the packages regardlessly. Unfortunately, in latest Meltano version, its installation `--force` flag poses an issue with utility plugins that it attempts re-installing the packages even though such package have been already installed while building Docker image. .
## Proposed changes

- Bump Python version to `<3.13` as we're upgrading to `3.12` version

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
