### PR TITLE
[App Update] Add the logic to ensure tap-postgres always return 1 row

### DIFF
--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -129,7 +129,8 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                             })
                     LOGGER.info('select latest row statement: %s', latest_sql)
                     cur.execute(latest_sql)
-                    for rec in cur:
+                    rec = cur.fetchone()
+                    if rec:
                         LOGGER.info(f"The latest record of the table is: {rec}")
                         record_message = post_db.selected_row_to_singer_message(stream,
                                                                                 rec,

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -154,11 +154,8 @@ def _get_select_latest_sql(params):
     table_name = params['table_name']
     select_sql = f"""
     SELECT {','.join(escaped_columns)}
-    FROM (
-        SELECT *
-        FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
-        ORDER BY {replication_key} DESC LIMIT 1
-    ) pg_speedup_trick;"""
+    FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
+    ORDER BY {replication_key} DESC LIMIT 1;"""
 
     return select_sql
 

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import singer
 
-from tests.utils import MockedConnect
+from tests.utils import MockedConnect, MockedConnectWithZeroRowAtFirst
 
 from tap_postgres.sync_strategies import incremental
 
@@ -65,6 +65,20 @@ class TestIncremental(TestCase):
         self.assertEqual(expected_state_replication_key_value,
                          actual_state['bookmarks'][self.stream['tap_stream_id']]['replication_key_value'],
                          )
+    
+    @patch("psycopg2.extras.register_hstore")
+    def test_sync_table_always_return_1_row(self, mocked_register_hstore):
+        with patch('psycopg2.connect') as mocked_connect:
+            mocked_connect.return_value.__enter__.return_value = MockedConnectWithZeroRowAtFirst()
+            desired_columns = ['foo_key']
+            self.state['bookmarks'] = {}
+            expected_state_replication_key_value = MockedConnect.cursor.return_value
+            actual_state = incremental.sync_table(self.conn_config, self.stream, self.state, desired_columns, self.md_map)
+            mocked_register_hstore.assert_called()
+
+            self.assertEqual(expected_state_replication_key_value,
+                            actual_state['bookmarks'][self.stream['tap_stream_id']]['replication_key_value'],
+                            )
 
     @patch('tap_postgres.sync_strategies.incremental.post_db.hstore_available')
     @patch('psycopg2.extras.register_hstore')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,56 +49,7 @@ class MockedConnect:
 
     def __init__(self, *args, **kwargs):
         pass
-
-class MockedConnectWithZeroRowAtFirst:
-    class cursor:
-        return_value = 1234
-        counter_limit = 0
-        fetchone_return_value = [1234]
-
-        def __init__(self, *args, **kwargs):
-            self.counter = 0
-            self.latest_sql = """
-                SELECT "foo_key"
-                FROM (
-                    SELECT *
-                    FROM "pg_catalog"."pg_tbl"
-                    ORDER BY "foo_key" DESC LIMIT 1
-                ) pg_speedup_trick;"""
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args, **kwargs):
-            pass
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            self.counter += 1
-            if self.counter < self.counter_limit:
-                return [self.return_value]
-            raise StopIteration
-
-        def fetchone(self):
-            return self.fetchone_return_value
-
-        def execute(self, *args, **kwargs):
-            sql = args[0]
-            if sql == self.latest_sql:
-                self.counter_limit = 1
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args, **kwargs):
-        pass
-
-    def __init__(self, *args, **kwargs):
-        self.latest_sql = kwargs.get("latest_sql", "")
     
-
 def get_test_connection_config(target_db='postgres', use_secondary=False):
     try:
         conn_config = {'host': os.environ['TAP_POSTGRES_HOST'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,8 @@ class MockedConnect:
 
     def __init__(self, *args, **kwargs):
         pass
-    
+
+
 def get_test_connection_config(target_db='postgres', use_secondary=False):
     try:
         conn_config = {'host': os.environ['TAP_POSTGRES_HOST'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,6 +50,54 @@ class MockedConnect:
     def __init__(self, *args, **kwargs):
         pass
 
+class MockedConnectWithZeroRowAtFirst:
+    class cursor:
+        return_value = 1234
+        counter_limit = 0
+        fetchone_return_value = [1234]
+
+        def __init__(self, *args, **kwargs):
+            self.counter = 0
+            self.latest_sql = """
+                SELECT "foo_key"
+                FROM (
+                    SELECT *
+                    FROM "pg_catalog"."pg_tbl"
+                    ORDER BY "foo_key" DESC LIMIT 1
+                ) pg_speedup_trick;"""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            pass
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.counter += 1
+            if self.counter < self.counter_limit:
+                return [self.return_value]
+            raise StopIteration
+
+        def fetchone(self):
+            return self.fetchone_return_value
+
+        def execute(self, *args, **kwargs):
+            sql = args[0]
+            if sql == self.latest_sql:
+                self.counter_limit = 1
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        self.latest_sql = kwargs.get("latest_sql", "")
+    
 
 def get_test_connection_config(target_db='postgres', use_secondary=False):
     try:


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/LOYAL-12052

# Background

Recently, we are facing the replication issue on the UAT RC-US ([this](https://rc-dataops.uat-rc-us.int.kaligo.com/dags/freshness-check/grid?dag_run_id=scheduled__2024-11-14T21%3A30%3A00%2B00%3A00&task_id=dbt-redshift_check-freshness&tab=logs
))
Most of the checks are related to the table `activity_trackings`

This is because `sdc_batched_at` of this table hasn’t been updated during the `elt-run` ([See this log](https://rc-dataops.uat-rc-us.int.kaligo.com/dags/elt-run/grid?dag_run_id=scheduled__2024-11-14T22:30:00+00:00&tab=logs&task_id=tap-postgres--loyalty_engine_remove-loyalty_engine-pii_target-redshift
))
In the log above, the result of the replication query did not return any row while logically, it should return at least one row because the replication query is in the format:

```SELECT ... FROM WHERE updated_at >= { bookmark_timestamp } - lookback-window```

The hypothesis is that:

In the time replication happened, the source Team has deleted recent rows whose `updated_at >= { bookmark_timestamp } - lookback-window`
That’s why the replication query return the empty result. Thus, target-redshift won’t update sdc_batched . That’s why the freshness-check failed.


# Design

Add a logic in the replication process that:
- if the result of the query is empty, we can select the latest row of the table to guarantee it will always return one row if that table is not empty.

# Impact

With this implementation, it will ensure that in every replication at least one row would be returned if that table is empty


# Caveats

None

# Testing

None

# Docs

None