### PR TITLE
[App Update] Recover mapping settings for tap-postgres [DATA-4769]

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import itertools
 import copy
 import psycopg2
@@ -395,6 +396,7 @@ def main_impl():
     limit = args.config.get('limit')
     skip_last_n_seconds = args.config.get('skip_last_n_seconds')
     look_back_n_seconds = args.config.get('look_back_n_seconds')
+    recover_mappings = args.config.get('recover_mappings')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -413,7 +415,8 @@ def main_impl():
         'use_secondary': args.config.get('use_secondary', False),
         'limit': int(limit) if limit else None,
         'skip_last_n_seconds': int(skip_last_n_seconds) if skip_last_n_seconds else None,
-        'look_back_n_seconds': int(look_back_n_seconds) if look_back_n_seconds else None
+        'look_back_n_seconds': int(look_back_n_seconds) if look_back_n_seconds else None,
+        'recover_mappings': ast.literal_eval(recover_mappings) if recover_mappings else {}
     }
 
     if conn_config['use_secondary']:

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -172,7 +172,7 @@ def _get_select_sql(params):
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
 
     if reconcile_dates:=recover_mappings.get(table_name):
-        where_statement = f"WHERE {replication_key} in ({','.join(map(lambda reconcile_date: f"'{reconcile_date}'", reconcile_dates))})"
+        where_statement = f"WHERE {replication_key}::DATE in ({','.join(map(lambda reconcile_date: f"'{reconcile_date}'", reconcile_dates))})"
     else:
         where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
             if replication_key_value else ""

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -172,11 +172,11 @@ def _get_select_sql(params):
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
 
     if reconcile_dates:=recover_mappings.get(table_name):
-        where_statement = f"WHERE {replication_key} in ({','.join(reconcile_dates)})"
+        where_statement = f"WHERE {replication_key} in ({','.join(map(lambda reconcile_date: f"'{reconcile_date}'", reconcile_dates))})"
     else:
         where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
             if replication_key_value else ""
-        
+
         where_incr += f" - interval '{params['look_back_n_seconds']} seconds'" \
             if params["look_back_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") and replication_key_value else ""
 

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -171,7 +171,7 @@ def _get_select_sql(params):
 
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
 
-    if reconcile_dates:=recover_mappings.get(table_name):
+    if reconcile_dates:=recover_mappings.get(f"{schema_name}-{table_name}"):
         where_statement = f"WHERE {replication_key}::DATE in ({','.join(map(lambda reconcile_date: f"'{reconcile_date}'", reconcile_dates))})"
     else:
         where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -89,7 +89,8 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                               "table_name": stream['table_name'],
                                               "limit": conn_info['limit'],
                                               "skip_last_n_seconds": conn_info['skip_last_n_seconds'],
-                                              "look_back_n_seconds": conn_info['look_back_n_seconds']
+                                              "look_back_n_seconds": conn_info['look_back_n_seconds'],
+                                              "recover_mappings": conn_info['recover_mappings'],
                                               })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)
@@ -166,20 +167,24 @@ def _get_select_sql(params):
     replication_key_value = params['replication_key_value']
     schema_name = params['schema_name']
     table_name = params['table_name']
+    recover_mappings = params['recover_mappings']
 
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
 
-    where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
-        if replication_key_value else ""
-    
-    where_incr += f" - interval '{params['look_back_n_seconds']} seconds'" \
-        if params["look_back_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") and replication_key_value else ""
+    if reconcile_dates:=recover_mappings.get(table_name):
+        where_statement = f"WHERE {replication_key} in ({','.join(reconcile_dates)})"
+    else:
+        where_incr = f"{replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
+            if replication_key_value else ""
+        
+        where_incr += f" - interval '{params['look_back_n_seconds']} seconds'" \
+            if params["look_back_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") and replication_key_value else ""
 
-    where_skip = f"{replication_key} <= NOW() - interval '{params['skip_last_n_seconds']} seconds'" \
-        if params["skip_last_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") else ""
+        where_skip = f"{replication_key} <= NOW() - interval '{params['skip_last_n_seconds']} seconds'" \
+            if params["skip_last_n_seconds"] and replication_key_sql_datatype.startswith("timestamp") else ""
 
-    where_statement = f"WHERE {where_incr}{' AND ' if where_incr and where_skip else ''}{where_skip}" \
-        if where_incr or where_skip else ""
+        where_statement = f"WHERE {where_incr}{' AND ' if where_incr and where_skip else ''}{where_skip}" \
+            if where_incr or where_skip else ""
 
     select_sql = f"""
     SELECT {','.join(escaped_columns)}


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/DATA-4769

# Background

To have the handy way to add the recovery dates (through the environment variable), we need to introduce another settings in tap-postgres  (for the usage of this setting, view this [rfc](https://www.notion.so/kaligo/RFC-Data-diff-recover-solutions-1d031c5427fd8088b920f5ff429787e5?pvs=4#1d731c5427fd80249e12f98a9c053a25)).

# Design

This setting is `recover_mappings`, having the format: {“schema-table“: [“%y-%m-%d“,…]}

The way the tap-postgres works is that: when it detects in the stream having this setting, then it will use this in the replication query for filtering:
```
  select_sql = f"""
    SELECT {','.join(escaped_columns)}
    FROM (
        SELECT *
        FROM {schema}.{table} 
        where replication_key in (recover_dates in recover_mappings)
        ORDER BY {replication_key} ASC {limit_statement}
    ) pg_speedup_trick;"""
```

# Impact

With this, recovery DAG in Airflow DAG could have the option to configure the `recovery_dates` in run time

# Caveats

None

# Testing

None

# Docs

None